### PR TITLE
Adaptacion Schedule

### DIFF
--- a/src/main/kotlin/ar/edu/unsam/pds/dto/request/ScheduleRequestDto.kt
+++ b/src/main/kotlin/ar/edu/unsam/pds/dto/request/ScheduleRequestDto.kt
@@ -6,15 +6,12 @@ import jakarta.validation.constraints.Min
 import jakarta.validation.constraints.NotEmpty
 import jakarta.validation.constraints.NotNull
 import jakarta.validation.constraints.Size
+import org.springframework.cglib.core.Local
 import java.time.DayOfWeek
 import java.time.LocalDate
 import java.time.LocalTime
 
 data class ScheduleRequestDto (
-
-    @field: NotEmpty(message = "Los dias no pueden estar vacios")
-    // deuda tecnica aqui. escribir la validacion personalizada
-    val days: List<DayOfWeek>,
 
     @field: NotNull(message = "La hora de inicio no puede ser nula")
     val startTime: LocalTime,
@@ -22,15 +19,15 @@ data class ScheduleRequestDto (
     @field: NotNull(message = "La hora de finalizaciin no puede ser nula")
     val endTime: LocalTime,
 
-    @field: NotNull(message = "La fecha de inicio no puede ser nula")
-    @field: FutureOrPresent(message = "La fecha de inicio no puede ser en el pasado")
-    val startDate: LocalDate,
+    val weekDay:DayOfWeek?,
 
-    @field: NotNull(message = "La fecha de finalización no puede ser nula")
-    @field: FutureOrPresent(message = "La fecha de inicio no puede ser en el pasado")
-    val endDate: LocalDate,
+    val date:LocalDate?,
 
-    @field: NotNull(message = "Las semanas de recurrencia no pueden ser nulas")
-    // deuda tecnica aqui. escribir la validacion personalizada
-    val recurrenceWeeks: RecurrenceWeeks
-)
+    /*por ahora dejo que weekDay y date puedan ser nulos, lei algo de una anotacion
+    personalizada para esto pero no sabía si usarlo. Valida en el service por ahora
+     */
+
+    @field: NotNull(message = "isVirtual no puede ser nulo")
+    val isVirtual: Boolean,
+
+    )

--- a/src/main/kotlin/ar/edu/unsam/pds/dto/request/ScheduleRequestDto.kt
+++ b/src/main/kotlin/ar/edu/unsam/pds/dto/request/ScheduleRequestDto.kt
@@ -1,11 +1,7 @@
 package ar.edu.unsam.pds.dto.request
 
 import ar.edu.unsam.pds.models.enums.RecurrenceWeeks
-import jakarta.validation.constraints.FutureOrPresent
-import jakarta.validation.constraints.Min
-import jakarta.validation.constraints.NotEmpty
-import jakarta.validation.constraints.NotNull
-import jakarta.validation.constraints.Size
+import jakarta.validation.constraints.*
 import org.springframework.cglib.core.Local
 import java.time.DayOfWeek
 import java.time.LocalDate
@@ -16,7 +12,7 @@ data class ScheduleRequestDto (
     @field: NotNull(message = "La hora de inicio no puede ser nula")
     val startTime: LocalTime,
 
-    @field: NotNull(message = "La hora de finalizaciin no puede ser nula")
+    @field: NotNull(message = "La hora de finalizacion no puede ser nula")
     val endTime: LocalTime,
 
     val weekDay:DayOfWeek?,
@@ -30,4 +26,21 @@ data class ScheduleRequestDto (
     @field: NotNull(message = "isVirtual no puede ser nulo")
     val isVirtual: Boolean,
 
+    @field: NotNull(message = "El ID no debe ser nulo")
+    @field: NotBlank(message = "El ID no debe estar en blanco")
+    @field: Pattern(
+        regexp = "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$",
+        message = "UUID debe ser valido"
+    )
+    val idClassroom: String?,
+
+    /*lo mismo de la anotacion personalizada en isVirtual y idClassroom*/
+
+    @field: NotNull(message = "El ID no debe ser nulo")
+    @field: NotBlank(message = "El ID no debe estar en blanco")
+    @field: Pattern(
+        regexp = "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$",
+        message = "UUID debe ser valido"
+    )
+    val idEvent: String,
     )

--- a/src/main/kotlin/ar/edu/unsam/pds/dto/response/ScheduleResponseDto.kt
+++ b/src/main/kotlin/ar/edu/unsam/pds/dto/response/ScheduleResponseDto.kt
@@ -5,11 +5,10 @@ import java.time.LocalDate
 import java.time.LocalTime
 
 data class ScheduleResponseDto (
-    val days: List<DayOfWeek>,
     val startTime: LocalTime,
     val endTime: LocalTime,
-    val startDate: LocalDate,
-    val endDate: LocalDate,
-    val recurrenceWeeks: String,
-    val listDates: List<String>
+    val weekDay:DayOfWeek?,
+    val date: LocalDate?,
+    val isVirtual:Boolean
 )
+

--- a/src/main/kotlin/ar/edu/unsam/pds/mappers/ScheduleMapper.kt
+++ b/src/main/kotlin/ar/edu/unsam/pds/mappers/ScheduleMapper.kt
@@ -7,13 +7,11 @@ object ScheduleMapper {
 
     fun buildScheduleDto(schedule: Schedule): ScheduleResponseDto {
         return ScheduleResponseDto(
-            days = schedule.days,
             startTime = schedule.startTime,
             endTime = schedule.endTime,
-            startDate = schedule.startDate,
-            endDate = schedule.endDate,
-            recurrenceWeeks = schedule.recurrenceWeeks.name,
-            listDates = schedule.generateSchedule()
+            date = schedule.date,
+            weekDay = schedule.weekDay,
+            isVirtual = schedule.isVirtual,
         )
     }
 }

--- a/src/main/kotlin/ar/edu/unsam/pds/models/Schedule.kt
+++ b/src/main/kotlin/ar/edu/unsam/pds/models/Schedule.kt
@@ -11,45 +11,14 @@ import java.util.*
 
 @Entity @Table(name = "APP_SCHEDULE")
 class Schedule(
-    val days: List<DayOfWeek>,
     val startTime: LocalTime,
     val endTime: LocalTime,
-    val startDate: LocalDate,
-    val endDate: LocalDate,
-    val recurrenceWeeks: RecurrenceWeeks
+    val day: DayOfWeek,
+    val date: LocalDate,
+    val isVirtual: Boolean,
 ) : Timestamp(), Serializable {
     @Id @GeneratedValue(strategy = GenerationType.UUID)
     lateinit var id: UUID
 
-    fun generateCompleteSchedule(): List<String> {
-        return days.flatMap { this.rangeOfDays(it) }
-    }
 
-    fun generateSchedule(): List<String> {
-        val today = LocalDate.now()
-        return days.flatMap { this.rangeOfDays(it) }
-            .filter { it >= today.toString() }
-    }
-
-    private fun rangeOfDays(day: DayOfWeek): Sequence<String> {
-        val initialDate = startDate.with(TemporalAdjusters.nextOrSame(day))
-
-        return generateSequence(initialDate) { date ->
-            date.plusWeeks(recurrenceWeeks.value)
-                .takeIf { it.isBefore(endDate) || it.isEqual(endDate) }
-        }.map { it.toString() }
-    }
-
-    fun isBeforeEndDate(date: LocalDate): Boolean {
-        return date.isBefore(endDate) || date.isEqual(endDate)
-    }
-
-    fun nextDate(): LocalDate? {
-        val today = LocalDate.now()
-        val scheduleDates = generateSchedule()
-            .map { LocalDate.parse(it) }
-            .filter { it.isAfter(today) || it.isEqual(today) }
-
-        return scheduleDates.minOrNull()
-    }
 }

--- a/src/main/kotlin/ar/edu/unsam/pds/models/Schedule.kt
+++ b/src/main/kotlin/ar/edu/unsam/pds/models/Schedule.kt
@@ -15,12 +15,24 @@ class Schedule(
     val startTime: LocalTime,
     val endTime: LocalTime,
     val weekDay: DayOfWeek?,
-    val date: LocalDate?,
+    val date: LocalDate?, //podra un schedule ser mas de un dia?
     val isVirtual: Boolean,
+
+    @ManyToOne(fetch = FetchType.EAGER)
+    @JoinColumn(name = "classroom_id", nullable = true)
+    val classroom: Classroom?,
+
+    /*@ManyToOne(fetch = FetchType.EAGER)
+    @JoinColumn(name = "event_id", nullable = true)
+    val event: Event,*/
+
 ) : Timestamp(), Serializable {
     @Id @GeneratedValue(strategy = GenerationType.UUID)
     lateinit var id: UUID
 
+   fun isBeforeEndDate(enteredDate: LocalDate): Boolean {
+        return enteredDate.isBefore(date) || enteredDate.isEqual(date)
+    }
 
 
 }

--- a/src/main/kotlin/ar/edu/unsam/pds/models/Schedule.kt
+++ b/src/main/kotlin/ar/edu/unsam/pds/models/Schedule.kt
@@ -15,16 +15,16 @@ class Schedule(
     val startTime: LocalTime,
     val endTime: LocalTime,
     val weekDay: DayOfWeek?,
-    val date: LocalDate?, //podra un schedule ser mas de un dia?
+    val date: LocalDate?,
     val isVirtual: Boolean,
 
     @ManyToOne(fetch = FetchType.EAGER)
     @JoinColumn(name = "classroom_id", nullable = true)
     val classroom: Classroom?,
 
-    /*@ManyToOne(fetch = FetchType.EAGER)
+    @ManyToOne(fetch = FetchType.EAGER)
     @JoinColumn(name = "event_id", nullable = true)
-    val event: Event,*/
+    val event: Event,
 
 ) : Timestamp(), Serializable {
     @Id @GeneratedValue(strategy = GenerationType.UUID)

--- a/src/main/kotlin/ar/edu/unsam/pds/models/Schedule.kt
+++ b/src/main/kotlin/ar/edu/unsam/pds/models/Schedule.kt
@@ -2,6 +2,7 @@ package ar.edu.unsam.pds.models
 
 import ar.edu.unsam.pds.models.enums.RecurrenceWeeks
 import jakarta.persistence.*
+import jakarta.validation.constraints.AssertTrue
 import java.io.Serializable
 import java.time.DayOfWeek
 import java.time.LocalDate
@@ -13,12 +14,13 @@ import java.util.*
 class Schedule(
     val startTime: LocalTime,
     val endTime: LocalTime,
-    val day: DayOfWeek,
-    val date: LocalDate,
+    val weekDay: DayOfWeek?,
+    val date: LocalDate?,
     val isVirtual: Boolean,
 ) : Timestamp(), Serializable {
     @Id @GeneratedValue(strategy = GenerationType.UUID)
     lateinit var id: UUID
+
 
 
 }

--- a/src/main/kotlin/ar/edu/unsam/pds/models/Schedule.kt
+++ b/src/main/kotlin/ar/edu/unsam/pds/models/Schedule.kt
@@ -30,7 +30,10 @@ class Schedule(
     @Id @GeneratedValue(strategy = GenerationType.UUID)
     lateinit var id: UUID
 
-   fun isBeforeEndDate(enteredDate: LocalDate): Boolean {
+    fun isBeforeEndDate(enteredDate: LocalDate): Boolean {
+        if (date == null) {
+            throw IllegalStateException("No se puede verificar la fecha porque 'date' es nulo en este Schedule")
+        }
         return enteredDate.isBefore(date) || enteredDate.isEqual(date)
     }
 

--- a/src/main/kotlin/ar/edu/unsam/pds/repository/ScheduleRepository.kt
+++ b/src/main/kotlin/ar/edu/unsam/pds/repository/ScheduleRepository.kt
@@ -33,7 +33,7 @@ interface ScheduleRepository : JpaRepository<Schedule, UUID>{
 """)
     fun getByPrincipal(@Param("query") query: String, @Param("principal") principal: Principal): Schedule?
 
-/*en principio por lo que vi cada event tenia un solo schedule*/
+/*en principio por lo que vi cada event tenia un solo schedule por eso cambbie a getByPrincipal*/
 
     @Query("""
         SELECT COUNT(schedules.id) = 1

--- a/src/main/kotlin/ar/edu/unsam/pds/repository/ScheduleRepository.kt
+++ b/src/main/kotlin/ar/edu/unsam/pds/repository/ScheduleRepository.kt
@@ -40,9 +40,9 @@ interface ScheduleRepository : JpaRepository<Schedule, UUID>{
         FROM Event i
         JOIN i.schedules schedules
         JOIN i.admin admins
-        WHERE schedules.id = :idCourse AND admins.id = :#{#principal.user.id}
+        WHERE schedules.id = :idSchedule AND admins.id = :#{#principal.user.id}
     """)
-    fun isOwner(@Param("idCourse") idCourse: UUID, @Param("principal") principal: Principal): Boolean
+    fun isOwner(@Param("idSchedule") idSchedule: UUID, @Param("principal") principal: Principal): Boolean
 
 
 }

--- a/src/main/kotlin/ar/edu/unsam/pds/repository/ScheduleRepository.kt
+++ b/src/main/kotlin/ar/edu/unsam/pds/repository/ScheduleRepository.kt
@@ -1,9 +1,48 @@
 package ar.edu.unsam.pds.repository
 
+import ar.edu.unsam.pds.dto.response.ScheduleResponseDto
+import ar.edu.unsam.pds.models.Course
 import ar.edu.unsam.pds.models.Schedule
+import ar.edu.unsam.pds.security.models.Principal
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
+import org.springframework.data.repository.query.Param
 import org.springframework.data.rest.core.annotation.RepositoryRestResource
 import java.util.*
 
 @RepositoryRestResource(exported = false)
-interface ScheduleRepository : JpaRepository<Schedule, UUID>
+interface ScheduleRepository : JpaRepository<Schedule, UUID>{
+
+    @Query("""
+    SELECT c FROM Schedule c
+    WHERE FUNCTION('TEXT', c.weekDay) LIKE concat('%', :query, '%')
+    OR FUNCTION('DATE_FORMAT', c.date, '%Y-%m-%d') LIKE concat('%', :query, '%')
+""")
+    fun getAllBy(@Param("query") query: String): MutableList<Schedule>
+
+
+    @Query("""
+    SELECT schedule FROM Event i
+    JOIN i.schedule schedule
+    JOIN i.admin admins
+    WHERE admins.id = :#{#principal.user.id}
+    AND (
+        FUNCTION('TEXT', schedule.weekDay) LIKE concat('%', :query, '%')
+        OR FUNCTION('DATE_FORMAT', schedule.date, '%Y-%m-%d') LIKE concat('%', :query, '%')
+    )
+""")
+    fun getByPrincipal(@Param("query") query: String, @Param("principal") principal: Principal): Schedule?
+
+/*en principio por lo que vi cada event tenia un solo schedule*/
+
+    @Query("""
+        SELECT COUNT(schedules.id) = 1
+        FROM Event i
+        JOIN i.schedules schedules
+        JOIN i.admin admins
+        WHERE schedules.id = :idCourse AND admins.id = :#{#principal.user.id}
+    """)
+    fun isOwner(@Param("idCourse") idCourse: UUID, @Param("principal") principal: Principal): Boolean
+
+
+}

--- a/src/main/kotlin/ar/edu/unsam/pds/services/CoursesService.kt
+++ b/src/main/kotlin/ar/edu/unsam/pds/services/CoursesService.kt
@@ -45,7 +45,7 @@ class CoursesService(
         if (!courseRepository.isOwner(uuid, principal)) {
             throw PermissionDeniedException("No se puede borrar un curso del cual no es propietario")
         }
-
+        //falta que elimine
     }
 
     @Transactional

--- a/src/main/kotlin/ar/edu/unsam/pds/services/CoursesService.kt
+++ b/src/main/kotlin/ar/edu/unsam/pds/services/CoursesService.kt
@@ -44,8 +44,10 @@ class CoursesService(
 
         if (!courseRepository.isOwner(uuid, principal)) {
             throw PermissionDeniedException("No se puede borrar un curso del cual no es propietario")
+        } else{
+            courseRepository.delete(course)
         }
-        //falta que elimine
+
     }
 
     @Transactional

--- a/src/main/kotlin/ar/edu/unsam/pds/services/ScheduleService.kt
+++ b/src/main/kotlin/ar/edu/unsam/pds/services/ScheduleService.kt
@@ -31,9 +31,8 @@ class ScheduleService(
         return schedules.map { ScheduleMapper.buildScheduleDto(this) }
     }
 
-    fun getAllByPrincipal(query: String, principal: Principal): List<CourseResponseDto> {
-        val schedules = scheduleRepository.getAllByPrincipal(query, principal)
-        return schedules.map { ScheduleMapper.buildScheduleDto(this) }
+    fun getByPrincipal(query: String, principal: Principal): Schedule? {
+        return scheduleRepository.getByPrincipal(query, principal)
     }
 
     fun getSchedule(idSchedule: String): ScheduleResponseDto {
@@ -48,8 +47,9 @@ class ScheduleService(
 
         if (!scheduleRepository.isOwner(uuid, principal)) {
             throw PermissionDeniedException("No se puede borrar un curso del cual no es propietario")
+        }else{
+            scheduleRepository.delete(schedule)
         }
-
     }
 
     @Transactional

--- a/src/main/kotlin/ar/edu/unsam/pds/services/ScheduleService.kt
+++ b/src/main/kotlin/ar/edu/unsam/pds/services/ScheduleService.kt
@@ -1,0 +1,21 @@
+package ar.edu.unsam.pds.services
+
+import ar.edu.unsam.pds.dto.response.ScheduleResponseDto
+import ar.edu.unsam.pds.models.Schedule
+import org.springframework.stereotype.Service
+import java.time.DayOfWeek
+import java.time.LocalDate
+
+@Service
+class ScheduleService {
+
+    fun createSchedule(schedule: ScheduleResponseDto){
+        if (isValidDateOrWeekDay(schedule.date,schedule.weekDay)){
+            //aca crea el schedule
+        }
+    }
+
+    fun isValidDateOrWeekDay(date: LocalDate?, weekDay:DayOfWeek?):Boolean{
+        return (date == null) != (weekDay == null)
+    }
+}

--- a/src/main/kotlin/ar/edu/unsam/pds/services/ScheduleService.kt
+++ b/src/main/kotlin/ar/edu/unsam/pds/services/ScheduleService.kt
@@ -1,21 +1,110 @@
 package ar.edu.unsam.pds.services
 
+import ar.edu.unsam.pds.dto.request.ScheduleRequestDto
+import ar.edu.unsam.pds.dto.response.CourseDetailResponseDto
+import ar.edu.unsam.pds.dto.response.CourseResponseDto
 import ar.edu.unsam.pds.dto.response.ScheduleResponseDto
+import ar.edu.unsam.pds.exceptions.NotFoundException
+import ar.edu.unsam.pds.exceptions.PermissionDeniedException
+import ar.edu.unsam.pds.mappers.CourseMapper
+import ar.edu.unsam.pds.mappers.ScheduleMapper
+import ar.edu.unsam.pds.models.Classroom
+import ar.edu.unsam.pds.models.Course
 import ar.edu.unsam.pds.models.Schedule
+import ar.edu.unsam.pds.repository.ClassroomRepository
+import ar.edu.unsam.pds.repository.ScheduleRepository
+import ar.edu.unsam.pds.security.models.Principal
+import jakarta.transaction.Transactional
 import org.springframework.stereotype.Service
 import java.time.DayOfWeek
 import java.time.LocalDate
+import java.util.*
 
 @Service
-class ScheduleService {
+class ScheduleService(
+    val scheduleRepository: ScheduleRepository,
+    val classroomRepository: ClassroomRepository
+    // val eventRepository : EventRepository
+) {
+    fun getAll(query: String): List<ScheduleResponseDto> {
+        val schedules = scheduleRepository.getAllBy(query)
+        return schedules.map { ScheduleMapper.buildScheduleDto(this) }
+    }
 
-    fun createSchedule(schedule: ScheduleResponseDto){
-        if (isValidDateOrWeekDay(schedule.date,schedule.weekDay)){
-            //aca crea el schedule
+    fun getAllByPrincipal(query: String, principal: Principal): List<CourseResponseDto> {
+        val schedules = scheduleRepository.getAllByPrincipal(query, principal)
+        return schedules.map { ScheduleMapper.buildScheduleDto(this) }
+    }
+
+    fun getSchedule(idSchedule: String): ScheduleResponseDto {
+        val schedule = findScheduleById(idSchedule)
+        return ScheduleMapper.buildScheduleDto(schedule)
+    }
+
+    @Transactional
+    fun deleteSchedule(idSchedule: String, principal: Principal) {
+        val schedule = findScheduleById(idSchedule)
+        val uuid = UUID.fromString(idSchedule)
+
+        if (!scheduleRepository.isOwner(uuid, principal)) {
+            throw PermissionDeniedException("No se puede borrar un curso del cual no es propietario")
+        }
+
+    }
+
+    @Transactional
+    fun deleteAllById(scheduleIds: List<String>, principal: Principal) {
+        scheduleIds.forEach { id ->
+            deleteSchedule(id, principal)
         }
     }
 
-    fun isValidDateOrWeekDay(date: LocalDate?, weekDay:DayOfWeek?):Boolean{
+    private fun findScheduleById(idSchedule: String): Schedule {
+        val uuid = UUID.fromString(idSchedule)
+        return scheduleRepository.findById(uuid).orElseThrow {
+            NotFoundException("Curso no encontrado para el uuid suministrado")
+        }
+    }
+
+
+    fun createSchedule(schedule: ScheduleRequestDto){
+        if (isValidDateOrWeekDay(schedule.date,schedule.weekDay)){
+            val idEvent = UUID.fromString(schedule.idEvent)
+            /*val event=eventRepository.findById(idEvent).orElseThrow {
+                NotFoundException("Evento no encontrado para el uuid suministrado")
+            }*/
+
+            val classroom=createClassroom(schedule)
+
+            val newSchedule=Schedule(
+                schedule.startTime,
+                schedule.endTime,
+                schedule.weekDay,
+                schedule.date,
+                schedule.isVirtual,
+                classroom,
+                //event
+            )
+
+            scheduleRepository.save(newSchedule)
+        }
+    }
+
+    private fun createClassroom(schedule: ScheduleRequestDto): Classroom? {
+        if (schedule.isVirtual){
+            return null
+        } else{
+            val idClassroom = UUID.fromString(schedule.idClassroom)
+            return classroomRepository.findById(idClassroom).orElseThrow{
+                NotFoundException("Aula no encontrada para el id suministrado")
+            }
+        }
+    }
+
+
+    private fun isValidDateOrWeekDay(date: LocalDate?, weekDay:DayOfWeek?):Boolean{
         return (date == null) != (weekDay == null)
     }
+
+
 }

--- a/src/main/kotlin/ar/edu/unsam/pds/services/ScheduleService.kt
+++ b/src/main/kotlin/ar/edu/unsam/pds/services/ScheduleService.kt
@@ -23,8 +23,8 @@ import java.util.*
 @Service
 class ScheduleService(
     val scheduleRepository: ScheduleRepository,
-    val classroomRepository: ClassroomRepository
-    // val eventRepository : EventRepository
+    val classroomRepository: ClassroomRepository,
+    val eventRepository : EventRepository
 ) {
     fun getAll(query: String): List<ScheduleResponseDto> {
         val schedules = scheduleRepository.getAllBy(query)
@@ -70,9 +70,9 @@ class ScheduleService(
     fun createSchedule(schedule: ScheduleRequestDto){
         if (isValidDateOrWeekDay(schedule.date,schedule.weekDay)){
             val idEvent = UUID.fromString(schedule.idEvent)
-            /*val event=eventRepository.findById(idEvent).orElseThrow {
+            val event=eventRepository.findById(idEvent).orElseThrow {
                 NotFoundException("Evento no encontrado para el uuid suministrado")
-            }*/
+            }
 
             val classroom=createClassroom(schedule)
 
@@ -83,7 +83,7 @@ class ScheduleService(
                 schedule.date,
                 schedule.isVirtual,
                 classroom,
-                //event
+                event
             )
 
             scheduleRepository.save(newSchedule)

--- a/src/main/kotlin/ar/edu/unsam/pds/services/ScheduleService.kt
+++ b/src/main/kotlin/ar/edu/unsam/pds/services/ScheduleService.kt
@@ -28,7 +28,7 @@ class ScheduleService(
 ) {
     fun getAll(query: String): List<ScheduleResponseDto> {
         val schedules = scheduleRepository.getAllBy(query)
-        return schedules.map { ScheduleMapper.buildScheduleDto(this) }
+        return schedules.map { ScheduleMapper.buildScheduleDto(it) }
     }
 
     fun getByPrincipal(query: String, principal: Principal): Schedule? {
@@ -76,6 +76,8 @@ class ScheduleService(
 
             val classroom=createClassroom(schedule)
 
+           // val newSchedule=schedule.copy(classroom=classroom, event=event)
+
             val newSchedule=Schedule(
                 schedule.startTime,
                 schedule.endTime,
@@ -93,11 +95,10 @@ class ScheduleService(
     private fun createClassroom(schedule: ScheduleRequestDto): Classroom? {
         if (schedule.isVirtual){
             return null
-        } else{
-            val idClassroom = UUID.fromString(schedule.idClassroom)
-            return classroomRepository.findById(idClassroom).orElseThrow{
-                NotFoundException("Aula no encontrada para el id suministrado")
-            }
+        }
+        val idClassroom = UUID.fromString(schedule.idClassroom)
+        return classroomRepository.findById(idClassroom).orElseThrow{
+            NotFoundException("Aula no encontrada para el id suministrado")
         }
     }
 


### PR DESCRIPTION
Se adapto el Schedule para que coincidiera con nuestra solución. Se borro startDate y endDate para que quede solo en una fecha y también days y recurrenceWeeks, al igual que todo lo asociado a esas variables. Deje isBeforeEndDate porque vi que los chicos lo usaban en event pero lo adapte para que pregunte solo por la fecha unica pero tenga en cuenta que puede ser null 
![image](https://github.com/user-attachments/assets/ddcb4593-dd87-4e9d-8057-a0cb9e641d31)

En el repositorio y service getAllByPrincipal fue cambiado a getByPrincipal porque en principio por lo que vi cada Event tenía un solo Schedule 
![image](https://github.com/user-attachments/assets/c1424756-80f0-42e6-ae0d-949238c5c3af)

Donde mas dudas surgen es armando que date pueda ser null si no lo es weekDay y que si isVirtual es true la classroom sea nula. En principio lo resolví desde el service pero no sé si será mas correcto armarlo desde el requestDTO, gpt me había recomendado usar una anotación personalizada si quería hacer eso y vi que en los comentarios también tenían pendiente armar algo así pero decidí hacerlo como yo conocía y consultar antes de tocar algo nuevo y mas complejo 

![image](https://github.com/user-attachments/assets/6079fe69-bbd6-4d78-b0c6-0eea05123631)

![image](https://github.com/user-attachments/assets/cadea9d3-6a82-43e7-ad52-8fc92c418fc1)


Todo lo que tenga Event por ahora va a dar error porque en esta versión todavía se llama Assignment pero como ya sabía que iba a ser cambiado lo escribí directamente así 