### PR TITLE
Endpoint Edit Event

### DIFF
--- a/src/main/kotlin/ar/edu/unsam/pds/controllers/EventController.kt
+++ b/src/main/kotlin/ar/edu/unsam/pds/controllers/EventController.kt
@@ -40,4 +40,10 @@ class EventController : UUIDValid() {
         @PathVariable eventID: String
     ){ eventService.deleteEvent(eventID) }
 
+    @PutMapping("{eventId}")
+    @Operation(summary = "Edit an event by ID")
+    fun editEvent(@PathVariable eventID: String,
+                  @RequestBody @Valid event: EventRequestDto){
+        eventService.editEvent(eventID,event)
+    }
 }

--- a/src/main/kotlin/ar/edu/unsam/pds/services/EventService.kt
+++ b/src/main/kotlin/ar/edu/unsam/pds/services/EventService.kt
@@ -41,22 +41,35 @@ class EventService(
     }
 
     @Transactional
+    fun editEvent(eventID:String, event: EventRequestDto){
+        val updatedEvent=buildEvent(event,eventID)
+        eventRepository.save(updatedEvent)
+    }
+
+    @Transactional
     fun createEvent(event: EventRequestDto){
+        val newEvent= buildEvent(event)
+        eventRepository.save(newEvent)
+    }
+
+    private fun buildEvent(event: EventRequestDto, existingID: String? = null):Event{
 
         val course= event.courseID?.let { courseService.findCourseById(it) }
         val period= event.periodID?.let{ periodService.findPeriodById(it) }
         val schedules: List<Schedule> = event.schedules.map {scheduleService.createSchedule(it) }
 
-        val newEvent = Event(event.name,
-                            isApproved = true,
-                            isCancelled = false,
+        val newEvent = Event(
+            event.name,
+            isApproved = true,
+            isCancelled = false,
         )
 
+        newEvent.id = UUID.fromString(existingID) ?: UUID.randomUUID()
         course?.let { newEvent.attachCourse(it) }
         period?.let { newEvent.addPeriod(it) }
         schedules.forEach { newEvent.addSchedule(it) }
 
-        eventRepository.save(newEvent)
+        return newEvent
     }
 
     @Transactional


### PR DESCRIPTION
Cree el endpoint para editar el evento. En el service tuve que hacer modificaciones tambien en la creación de eventos para evitar repetir codigo. En el service lo que anteriormente era createEvent ahora es buildEvent y construye el evento a partir del dto asignandole el id que puede recibir por parametro para el caso donde se este editando, sino le asigna uno random. Asi se puede aprovechar para el endpoint de createEvent y de editEvent