### PR TITLE
CRUD Period

### DIFF
--- a/src/main/kotlin/ar/edu/unsam/pds/bootstrap/InitEvents.kt
+++ b/src/main/kotlin/ar/edu/unsam/pds/bootstrap/InitEvents.kt
@@ -43,6 +43,8 @@ class InitEvents : BootstrapGeneric("Events") {
         val spd = this.findCourseByName(name = "Sistemas de Procesamiento de Datos")
         val primerCuatrimestre = Period("Primer Cuatrimestre 2025", LocalDate.parse("2025-03-01"),LocalDate.parse("2025-07-31"))
         periodRepository.save(primerCuatrimestre)
+        val segundoCuatrimestre = Period("Segundo Cuatrimestre 2025", LocalDate.parse("2025-08-01"),LocalDate.parse("2025-11-30"))
+        periodRepository.save(segundoCuatrimestre)
 
         val cursadaMate1TM = Event(
             name = "Turno Mañana",

--- a/src/main/kotlin/ar/edu/unsam/pds/controllers/PeriodController.kt
+++ b/src/main/kotlin/ar/edu/unsam/pds/controllers/PeriodController.kt
@@ -1,0 +1,91 @@
+package ar.edu.unsam.pds.controllers
+
+import ar.edu.unsam.pds.dto.request.PeriodRequestDto
+import ar.edu.unsam.pds.dto.response.CustomResponse
+import ar.edu.unsam.pds.mappers.PeriodMapper
+import ar.edu.unsam.pds.services.PeriodService
+import io.swagger.v3.oas.annotations.Operation
+import jakarta.validation.Valid
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.CrossOrigin
+import org.springframework.web.bind.annotation.DeleteMapping
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.PutMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("api/periods")
+@CrossOrigin("*")
+class PeriodController : UUIDValid () {
+    @Autowired lateinit var periodService: PeriodService
+
+    @GetMapping()
+    @Operation(summary = "Get all periods")
+    fun getAllPeriods(): ResponseEntity<CustomResponse> {
+        return ResponseEntity.status(200).body(
+            CustomResponse(
+                message = "Periodos obtenidos con exito",
+                data = periodService.getAllPeriods().map { PeriodMapper.buildPeriodDto(it)}
+            )
+        )
+    }
+
+    @GetMapping("/{periodID}")
+    @Operation(summary = "Get a period by ID")
+    fun getPeriod(@PathVariable(value="periodID", required= true) periodID: String): ResponseEntity<CustomResponse> {
+        validatedUUID(periodID)
+        return ResponseEntity.status(200).body(
+            CustomResponse(
+                message = "Periodo obtenido con exito",
+                data = PeriodMapper.buildPeriodDto(periodService.findPeriodById(periodID))
+            )
+        )
+    }
+
+    @PostMapping("")
+    @Operation(summary = "Create a period")
+    fun createPeriod(
+        @RequestBody @Valid period: PeriodRequestDto
+    ): ResponseEntity<CustomResponse> {
+        return ResponseEntity.status(201).body(
+            CustomResponse(
+                message = "Periodo creado con exito",
+                data = periodService.createPeriod(period)
+            )
+        )
+    }
+
+    @DeleteMapping("{periodId}")
+    @Operation(summary = "Delete a period by ID")
+    fun deletePeriod(
+        @PathVariable periodId: String
+    ): ResponseEntity<CustomResponse> {
+        validatedUUID(periodId)
+        return ResponseEntity.status(200).body(
+            CustomResponse(
+                message = "Periodo eliminado con exito",
+                data = periodService.deletePeriod(periodId)
+            )
+        )
+    }
+
+    @PutMapping("{periodId}")
+    @Operation(summary = "Edit a period by ID")
+    fun editPeriod(
+        @PathVariable periodId: String,
+        @RequestBody @Valid period: PeriodRequestDto
+    ): ResponseEntity<CustomResponse> {
+        validatedUUID(periodId)
+        return ResponseEntity.status(200).body(
+            CustomResponse(
+                message = "Periodo editado con exito",
+                data = periodService.updatePeriod(periodId, period)
+            )
+        )
+    }
+}

--- a/src/main/kotlin/ar/edu/unsam/pds/dto/request/PeriodRequestDto.kt
+++ b/src/main/kotlin/ar/edu/unsam/pds/dto/request/PeriodRequestDto.kt
@@ -13,11 +13,9 @@ class PeriodRequestDto (
     val title: String = "",
 
     @field: NotNull(message = "La fecha de inicio no puede ser nula")
-    @field: FutureOrPresent(message = "La fecha de inicio no puede ser en el pasado")
     val startDate: LocalDate,
 
     @field: NotNull(message = "La fecha de finalización no puede ser nula")
-    @field: FutureOrPresent(message = "La fecha de finalizacion no puede ser en el pasado")
     val endDate: LocalDate,
 
 )

--- a/src/main/kotlin/ar/edu/unsam/pds/models/Period.kt
+++ b/src/main/kotlin/ar/edu/unsam/pds/models/Period.kt
@@ -7,9 +7,9 @@ import java.util.*
 
 @Entity @Table(name = "APP_PERIOD")
 class Period(
-    val title: String,
-    val startDate: LocalDate,
-    val endDate: LocalDate,
+    var title: String,
+    var startDate: LocalDate,
+    var endDate: LocalDate,
 ): Timestamp(),Serializable
 {
     @Id

--- a/src/main/kotlin/ar/edu/unsam/pds/repository/PeriodRepository.kt
+++ b/src/main/kotlin/ar/edu/unsam/pds/repository/PeriodRepository.kt
@@ -6,4 +6,6 @@ import org.springframework.data.rest.core.annotation.RepositoryRestResource
 import java.util.*
 
 @RepositoryRestResource(exported = false)
-interface PeriodRepository: JpaRepository<Period, UUID>
+interface PeriodRepository: JpaRepository<Period, UUID> {
+    fun findAllByOrderByStartDateDesc(): List<Period>
+}

--- a/src/main/kotlin/ar/edu/unsam/pds/security/FilterChainConfiguration.kt
+++ b/src/main/kotlin/ar/edu/unsam/pds/security/FilterChainConfiguration.kt
@@ -107,6 +107,13 @@ class FilterChainConfiguration {
                 antMatcher(POST, "/api/schedules"),
                 antMatcher(PUT, "/api/schedules"),
                 antMatcher(DELETE, "/api/schedules/*"),
+
+                //Periods
+                antMatcher(GET, "/api/periods"),
+                antMatcher(GET, "/api/periods/*"),
+                antMatcher(POST, "/api/periods"),
+                antMatcher(PUT, "/api/periods/*"),
+                antMatcher(DELETE, "/api/periods/*"),
             ).permitAll()
 
             // H2 DataBase @@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@

--- a/src/main/kotlin/ar/edu/unsam/pds/services/PeriodService.kt
+++ b/src/main/kotlin/ar/edu/unsam/pds/services/PeriodService.kt
@@ -20,11 +20,10 @@ import java.util.*
 @Service
 class PeriodService(
     private val periodRepository : PeriodRepository,
-    private val eventRepository: EventRepository,
 ) {
 
     fun getAllPeriods(): List<Period> {
-        return periodRepository.findAll()
+        return periodRepository.findAllByOrderByStartDateDesc()
     }
 
     fun findPeriodById(idPeriod: String): Period {

--- a/src/main/kotlin/ar/edu/unsam/pds/services/PeriodService.kt
+++ b/src/main/kotlin/ar/edu/unsam/pds/services/PeriodService.kt
@@ -23,6 +23,10 @@ class PeriodService(
     private val eventRepository: EventRepository,
 ) {
 
+    fun getAllPeriods(): List<Period> {
+        return periodRepository.findAll()
+    }
+
     fun findPeriodById(idPeriod: String): Period {
         val uuid = UUID.fromString(idPeriod)
         return periodRepository.findById(uuid).orElseThrow {
@@ -31,7 +35,7 @@ class PeriodService(
     }
 
     @Transactional
-    fun createPeriod(period: PeriodRequestDto): PeriodResponseDto? {
+    fun createPeriod(period: PeriodRequestDto): UUID {
         if(isValidEndDate(period.startDate, period.endDate)){
             val newPeriod = Period(
                 period.title,
@@ -39,8 +43,28 @@ class PeriodService(
                 period.endDate,
             )
             periodRepository.save(newPeriod)
-            return PeriodMapper.buildPeriodDto(newPeriod)
+            return newPeriod.id
         } else{
+            throw BadRequestException("La fecha de finalizacion no puede ser previa a la de inicio")
+        }
+    }
+
+    fun deletePeriod(idPeriod: String) {
+        val periodDeleted = findPeriodById(idPeriod)
+        periodRepository.delete(periodDeleted)
+    }
+
+    fun updatePeriod(
+        idPeriod: String,
+        period: PeriodRequestDto,
+    ): PeriodResponseDto {
+        val periodToUpdate = findPeriodById(idPeriod)
+        if (isValidEndDate(period.startDate, period.endDate)) {
+            periodToUpdate.title = period.title
+            periodToUpdate.startDate = period.startDate
+            periodToUpdate.endDate = period.endDate
+            return PeriodMapper.buildPeriodDto(periodRepository.save(periodToUpdate))
+        } else {
             throw BadRequestException("La fecha de finalizacion no puede ser previa a la de inicio")
         }
     }


### PR DESCRIPTION
Armo CRUD para Period.
En el modelo cambio a var las referencias actualizables
Luego en el controller hay:

- Dos GET
1- Traer un Period por ID
2- Traer todos los Period ordenados por fecha (los que tienen fecha de inicio mas reciente van primero)

- PUT
Modifica los campos de nombre, fecha de inicio y fecha de finalización.
Acá me queda la duda de si corresponde en el PeriodRequetsDTO que exista esta restricción:
`    @field: FutureOrPresent(message = "La fecha de inicio no puede ser en el pasado")`
`    val startDate: LocalDate,`
`    @field: FutureOrPresent(message = "La fecha de finalizacion no puede ser en el pasado")`
`    val endDate: LocalDate,`
Ya que podría querer editar la fecha de inicio desde el futuro y con esto no podría.

- POST
Da de alta un Period, solo requiere nombre y fechas de inicio y fin. Me surge la misma duda que con el PUT. Si quiero crear el Period del primer cuatrimestre del 2025 hoy que es 26/4 no me dejaría ponerle la fecha real de inicio de cuatri que fue el 3/3.

- DELETE
Tuve que agregar un nuevo Period para probar este endpoint porque no podía borrar el que estaba. Por lo que vi no se podía ya que ese Period tiene Eventos relacionados y no esta configurado el CASCADE o el comportamiento que debería tener la BBDD ante una eliminación de Period. Yo creo que como la relación es parcial se debería borrar tranquilamente y los eventos que tengan asignados ese periodo deberían quedar con ese campo en null. Que piensan?

**No cree un Bootstrap para los Period, estan los dos instanciados en el bootstrap de Event. Si corresponde lo hago y los paso para ese archivo.**

> Todos los métodos del controller fueron probados en Insomnia

> Todos respetan la normativa de retornar un ResponseEntity < CustomResponse >

> Los permisos para los endpoints en el archivo _FilterChainConfiguration.kt_ los puse en la parte de PUBLIC para poder probarlo pero entiendo que esto solo debería hacerlo Luciano (USER/ADMIN)